### PR TITLE
elastic-opentelemetry-instrumentation-openai: a bit more slack for durations

### DIFF
--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/test_chat_completions.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/test_chat_completions.py
@@ -112,7 +112,7 @@ class OpenaiMixin(VCRMixin):
                     },
                 ),
             ],
-            est_value_delta=0.01,
+            est_value_delta=0.1,
         )
 
     def assertErrorOperationDurationMetric(self, metric: Histogram, attributes: dict, data_point: float = None):


### PR DESCRIPTION
## What does this pull request do?

Permit more delta for the operation duration metric tests so they don't fail on github.

## Related issues

None