### PR TITLE
elastic-opentelemetry-instrumentation-openai: schema versions are strings

### DIFF
--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/__init__.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/__init__.py
@@ -77,9 +77,9 @@ class OpenAIInstrumentor(BaseInstrumentor):
         capture_content = "true" if kwargs.get("capture_content") else "false"
         self.capture_content = os.environ.get(ELASTIC_OTEL_GENAI_CAPTURE_CONTENT, capture_content).lower() == "true"
         tracer_provider = kwargs.get("tracer_provider")
-        self.tracer = get_tracer(__name__, __version__, tracer_provider, schema_url=Schemas.V1_27_0)
+        self.tracer = get_tracer(__name__, __version__, tracer_provider, schema_url=Schemas.V1_27_0.value)
         meter_provider = kwargs.get("meter_provider")
-        self.meter = get_meter(__name__, __version__, meter_provider, schema_url=Schemas.V1_27_0)
+        self.meter = get_meter(__name__, __version__, meter_provider, schema_url=Schemas.V1_27_0.value)
         self.token_usage_metric = create_gen_ai_client_token_usage(self.meter)
         self.operation_duration_metric = create_gen_ai_client_operation_duration(self.meter)
 


### PR DESCRIPTION
## What does this pull request do?

Enum attributes are not strings and opentelemetry-instrument json serializer is failing to serialize them.
Reproducible with:

opentelemetry-instrument --metrics_exporter=console --traces_exporter=none examples/use_openai.py

