### PR TITLE
elastic-opentelemetry-instrumentation-openai: test with latest openai

### DIFF
--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/dev-requirements.txt
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/dev-requirements.txt
@@ -49,7 +49,7 @@ jiter==0.5.0
     # via openai
 multidict==6.1.0
     # via yarl
-openai==1.46.0
+openai==1.50.2
     # via elastic-opentelemetry-instrumentation-openai (pyproject.toml)
 opentelemetry-api==1.27.0
     # via

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/test_chat_completions.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/test_chat_completions.py
@@ -1166,4 +1166,8 @@ class TestAsyncChatCompletions(OpenaiMixin, TestBase, IsolatedAsyncioTestCase):
         self.assertEqual(span.events, ())
 
         (operation_duration_metric,) = self.get_sorted_metrics()
-        self.assertErrorOperationDurationMetric(operation_duration_metric, {"error.type": "APIConnectionError"})
+        self.assertErrorOperationDurationMetric(
+            operation_duration_metric,
+            {"error.type": "APIConnectionError"},
+            data_point=0.0072969673201441765,
+        )


### PR DESCRIPTION
## What does this pull request do?

Adapt tests to work with faster error handling from versions newer than 1.46.0 that are near a second faster for a particular test case.