### PR TITLE
elastic-opentelemetry-instrumentation-openai: fix tracing of openai client optional params

### DIFF
--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/helpers.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/helpers.py
@@ -112,17 +112,17 @@ def _get_span_attributes_from_wrapper(instance, kwargs):
                 elif scheme == "https":
                     span_attributes[SERVER_PORT] = 443
 
-    if frequency_penalty := kwargs.get("frequency_penalty") is not None:
+    if (frequency_penalty := kwargs.get("frequency_penalty")) is not None:
         span_attributes[GEN_AI_REQUEST_FREQUENCY_PENALTY] = frequency_penalty
-    if max_tokens := kwargs.get("max_tokens") is not None:
+    if (max_tokens := kwargs.get("max_completion_tokens", kwargs.get("max_tokens"))) is not None:
         span_attributes[GEN_AI_REQUEST_MAX_TOKENS] = max_tokens
-    if presence_penalty := kwargs.get("presence_penalty") is not None:
+    if (presence_penalty := kwargs.get("presence_penalty")) is not None:
         span_attributes[GEN_AI_REQUEST_PRESENCE_PENALTY] = presence_penalty
-    if temperature := kwargs.get("temperature") is not None:
+    if (temperature := kwargs.get("temperature")) is not None:
         span_attributes[GEN_AI_REQUEST_TEMPERATURE] = temperature
-    if top_p := kwargs.get("top_p") is not None:
+    if (top_p := kwargs.get("top_p")) is not None:
         span_attributes[GEN_AI_REQUEST_TOP_P] = top_p
-    if stop_sequences := kwargs.get("stop") is not None:
+    if (stop_sequences := kwargs.get("stop")) is not None:
         if isinstance(stop_sequences, str):
             stop_sequences = [stop_sequences]
         span_attributes[GEN_AI_REQUEST_STOP_SEQUENCES] = stop_sequences

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/cassettes/TestChatCompletions.test_all_the_client_options.yaml
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/cassettes/TestChatCompletions.test_all_the_client_options.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": "Answer in up to 3 words: Which
+      ocean contains the falkland islands?"}], "model": "gpt-4o-mini", "frequency_penalty":
+      0, "max_completion_tokens": 100, "presence_penalty": 0, "stop": "foo", "temperature":
+      1, "top_p": 1}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.50.2
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.50.2
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.12
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3SQMU/DMBCF9/wKy3NTpSE0IVslxAZUqoABoch1LompYxv7QoGq/x05aZMysHh4
+        373nd3cICKGipDmhvGHIWyPD1e1TWS8X6/3Lh7q6W6vk+WH3k3zu73ebZUxn3qG378Dx7Jpz3RoJ
+        KLQaMLfAEHzqIo3TNL1JoqQHrS5BelttMEx02AolwjiKkzBKw0V2cjdacHA0J68BIYQc+tf3VCV8
+        0ZxEs7PSgnOsBpqPQ4RQq6VXKHNOOGQK6WyCXCsE1Vff6A4bskLJFApOHjkwNb+ctVB1jvm+qpPy
+        pB/Hz6WujdVbd+KjXgklXFNYYE4r/5FDbWhPjwEhb/2S3Z/e1FjdGixQ70D5wDgZ4uh02gmeGWpk
+        8sKT/ecpSkAmpLu4Ex3qCVVPAdHYsV+Sum+H0BaVUDVYY8VwtsoUVXa9BbZMs4QGx+AXAAD//wMA
+        sMwiB0QCAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8cbbd9faeab95a0d-MXP
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 01 Oct 2024 10:43:24 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      openai-organization: test_openai_org_key
+      openai-processing-ms:
+      - '145'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '200000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '199966'
+      x-ratelimit-reset-requests:
+      - 8.64s
+      x-ratelimit-reset-tokens:
+      - 10ms
+      x-request-id:
+      - req_b2c77a93a9995fac4529c05464b89f7e
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## What does this pull request do?

Fix some precedence bugs when settings optional client attributes, before the fixes all the values had `true` as value.