### PR TITLE
ci: don't run integrations tests without openai api key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       working-directory: ${{ env.working_dir }}
     - run: pytest
       working-directory: ${{ env.working_dir }}
-    - if: ${{ env[matrix.python-version] == '3.12' && !env[matrix.openai-version] && secrets.OPENAI_API_KEY != '' }}
+    - if: ${{ env[matrix.python-version] == '3.12' && !env[matrix.openai-version] && env.OPENAI_API_KEY != '' }}
       # Only run on latest python and openai client version because we are calling openai
       run: pytest --integration-tests
       working-directory: ${{ env.working_dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       working-directory: ${{ env.working_dir }}
     - run: pytest
       working-directory: ${{ env.working_dir }}
-    - if: ${{ env[matrix.python-version] == '3.12' && !env[matrix.openai-version] }}
+    - if: ${{ env[matrix.python-version] == '3.12' && !env[matrix.openai-version] && secrets.OPENAI_API_KEY != '' }}
       # Only run on latest python and openai client version because we are calling openai
       run: pytest --integration-tests
       working-directory: ${{ env.working_dir }}


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

CI runs from PR done from forks are failing the integrations tests step because the OPENAI_API_KEY secret is not available to them.