### PR TITLE
openai: decouple metrics from span recording

### DIFF
--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/__init__.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/__init__.py
@@ -25,16 +25,16 @@ from opentelemetry.instrumentation.openai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
 )
 from opentelemetry.instrumentation.openai.helpers import (
-    _get_embeddings_span_attributes_from_response,
-    _get_embeddings_span_attributes_from_wrapper,
+    _get_attributes_from_response,
+    _get_attributes_from_wrapper,
+    _get_embeddings_attributes_from_response,
+    _get_embeddings_attributes_from_wrapper,
     _get_event_attributes,
-    _get_span_attributes_from_response,
-    _get_span_attributes_from_wrapper,
     _record_operation_duration_metric,
     _record_token_usage_metrics,
     _send_log_events_from_choices,
     _send_log_events_from_messages,
-    _span_name_from_span_attributes,
+    _span_name_from_attributes,
 )
 from opentelemetry.instrumentation.openai.package import _instruments
 from opentelemetry.instrumentation.openai.version import __version__
@@ -134,10 +134,10 @@ class OpenAIInstrumentor(BaseInstrumentor):
     def _chat_completion_wrapper(self, wrapped, instance, args, kwargs):
         logger.debug(f"openai.resources.chat.completions.Completions.create kwargs: {kwargs}")
 
-        span_attributes = _get_span_attributes_from_wrapper(instance, kwargs)
+        span_attributes = _get_attributes_from_wrapper(instance, kwargs)
         event_attributes = _get_event_attributes()
 
-        span_name = _span_name_from_span_attributes(span_attributes)
+        span_name = _span_name_from_attributes(span_attributes)
         with self.tracer.start_as_current_span(
             name=span_name,
             kind=SpanKind.CLIENT,
@@ -179,7 +179,7 @@ class OpenAIInstrumentor(BaseInstrumentor):
 
             logger.debug(f"openai.resources.chat.completions.Completions.create result: {result}")
 
-            response_attributes = _get_span_attributes_from_response(
+            response_attributes = _get_attributes_from_response(
                 result.id, result.model, result.choices, result.usage, getattr(result, "service_tier", None)
             )
             if span.is_recording():
@@ -204,10 +204,10 @@ class OpenAIInstrumentor(BaseInstrumentor):
     async def _async_chat_completion_wrapper(self, wrapped, instance, args, kwargs):
         logger.debug(f"openai.resources.chat.completions.AsyncCompletions.create kwargs: {kwargs}")
 
-        span_attributes = _get_span_attributes_from_wrapper(instance, kwargs)
+        span_attributes = _get_attributes_from_wrapper(instance, kwargs)
         event_attributes = _get_event_attributes()
 
-        span_name = _span_name_from_span_attributes(span_attributes)
+        span_name = _span_name_from_attributes(span_attributes)
         with self.tracer.start_as_current_span(
             name=span_name,
             kind=SpanKind.CLIENT,
@@ -249,7 +249,7 @@ class OpenAIInstrumentor(BaseInstrumentor):
 
             logger.debug(f"openai.resources.chat.completions.AsyncCompletions.create result: {result}")
 
-            response_attributes = _get_span_attributes_from_response(
+            response_attributes = _get_attributes_from_response(
                 result.id, result.model, result.choices, result.usage, getattr(result, "service_tier", None)
             )
             if span.is_recording():
@@ -272,9 +272,9 @@ class OpenAIInstrumentor(BaseInstrumentor):
             return result
 
     def _embeddings_wrapper(self, wrapped, instance, args, kwargs):
-        span_attributes = _get_embeddings_span_attributes_from_wrapper(instance, kwargs)
+        span_attributes = _get_embeddings_attributes_from_wrapper(instance, kwargs)
 
-        span_name = _span_name_from_span_attributes(span_attributes)
+        span_name = _span_name_from_attributes(span_attributes)
         with self.tracer.start_as_current_span(
             name=span_name,
             kind=SpanKind.CLIENT,
@@ -293,7 +293,7 @@ class OpenAIInstrumentor(BaseInstrumentor):
                 _record_operation_duration_metric(self.operation_duration_metric, error_attributes, start_time)
                 raise
 
-            response_attributes = _get_embeddings_span_attributes_from_response(result.model, result.usage)
+            response_attributes = _get_embeddings_attributes_from_response(result.model, result.usage)
             if span.is_recording():
                 for k, v in response_attributes.items():
                     span.set_attribute(k, v)
@@ -307,9 +307,9 @@ class OpenAIInstrumentor(BaseInstrumentor):
             return result
 
     async def _async_embeddings_wrapper(self, wrapped, instance, args, kwargs):
-        span_attributes = _get_embeddings_span_attributes_from_wrapper(instance, kwargs)
+        span_attributes = _get_embeddings_attributes_from_wrapper(instance, kwargs)
 
-        span_name = _span_name_from_span_attributes(span_attributes)
+        span_name = _span_name_from_attributes(span_attributes)
         with self.tracer.start_as_current_span(
             name=span_name,
             kind=SpanKind.CLIENT,
@@ -328,7 +328,7 @@ class OpenAIInstrumentor(BaseInstrumentor):
                 _record_operation_duration_metric(self.operation_duration_metric, error_attributes, start_time)
                 raise
 
-            response_attributes = _get_embeddings_span_attributes_from_response(result.model, result.usage)
+            response_attributes = _get_embeddings_attributes_from_response(result.model, result.usage)
             if span.is_recording():
                 for k, v in response_attributes.items():
                     span.set_attribute(k, v)

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/helpers.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/helpers.py
@@ -68,7 +68,7 @@ else:
     CompletionUsage = None
 
 
-def _get_span_attributes_from_response(
+def _get_attributes_from_response(
     response_id: str,
     model: str,
     choices,
@@ -93,7 +93,7 @@ def _get_span_attributes_from_response(
     return attributes
 
 
-def _get_embeddings_span_attributes_from_response(model: str, usage: CompletionUsage) -> Attributes:
+def _get_embeddings_attributes_from_response(model: str, usage: CompletionUsage) -> Attributes:
     return {
         GEN_AI_RESPONSE_MODEL: model,
         GEN_AI_USAGE_INPUT_TOKENS: usage.prompt_tokens,
@@ -117,7 +117,7 @@ def _attributes_from_client(client) -> Attributes:
     return span_attributes
 
 
-def _get_span_attributes_from_wrapper(instance, kwargs) -> Attributes:
+def _get_attributes_from_wrapper(instance, kwargs) -> Attributes:
     span_attributes = {
         GEN_AI_OPERATION_NAME: "chat",
         GEN_AI_SYSTEM: "openai",
@@ -158,7 +158,7 @@ def _get_span_attributes_from_wrapper(instance, kwargs) -> Attributes:
     return span_attributes
 
 
-def _span_name_from_span_attributes(attributes: Attributes) -> str:
+def _span_name_from_attributes(attributes: Attributes) -> str:
     request_model = attributes.get(GEN_AI_REQUEST_MODEL)
     return (
         f"{attributes[GEN_AI_OPERATION_NAME]} {request_model}"
@@ -167,7 +167,7 @@ def _span_name_from_span_attributes(attributes: Attributes) -> str:
     )
 
 
-def _get_embeddings_span_attributes_from_wrapper(instance, kwargs) -> Attributes:
+def _get_embeddings_attributes_from_wrapper(instance, kwargs) -> Attributes:
     span_attributes = {
         GEN_AI_OPERATION_NAME: "embeddings",
         GEN_AI_SYSTEM: "openai",

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/wrappers.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/wrappers.py
@@ -18,7 +18,7 @@ import logging
 
 from opentelemetry._events import EventLogger
 from opentelemetry.instrumentation.openai.helpers import (
-    _get_span_attributes_from_response,
+    _get_attributes_from_response,
     _record_operation_duration_metric,
     _record_token_usage_metrics,
     _send_log_events_from_stream_choices,
@@ -73,7 +73,7 @@ class StreamWrapper:
             _record_operation_duration_metric(self.operation_duration_metric, error_attributes, self.start_time)
             return
 
-        response_attributes = _get_span_attributes_from_response(
+        response_attributes = _get_attributes_from_response(
             self.response_id, self.model, self.choices, self.usage, self.service_tier
         )
         if self.span.is_recording():


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

When spans are not recording the attributes are not accessible and so we'll crash trying to access them in metrics code. So decouple the metrics code from the span and instead use the plain attributes.

## Related issues

Closes #53 
