### PR TITLE
Maps non-string, non-dict schema as json_schema

### DIFF
--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/pyproject.toml
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/pyproject.toml
@@ -41,7 +41,7 @@ Homepage = "https://github.com/elastic/elastic-otel-python-instrumentations"
 "Bug Tracker" = "https://github.com/elastic/elastic-otel-python-instrumentations/issues"
 
 [project.optional-dependencies]
-dev = ["pytest", "pip-tools", "openai", "numpy", "opentelemetry-test-utils", "vcrpy", "pytest-asyncio", "pytest-vcr"]
+dev = ["pytest", "pip-tools", "openai", "numpy", "opentelemetry-test-utils", "vcrpy", "pytest-asyncio", "pytest-vcr", "pydantic"]
 instruments = [
   "openai >= 1.2.0",
 ]

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/helpers.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/helpers.py
@@ -164,6 +164,10 @@ def _get_attributes_from_wrapper(instance, kwargs) -> Attributes:
         if isinstance(response_format, Mapping):
             if _is_set(response_format_type := response_format.get("type")):
                 span_attributes[GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT] = response_format_type
+        elif not isinstance(response_format, str):
+            # Assume structured output lazily parsed to a schema via type_to_response_format_param or similar.
+            # e.g. pydantic._internal._model_construction.ModelMetaclass
+            span_attributes[GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT] = "json_schema"
         else:
             span_attributes[GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT] = response_format
 

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/helpers.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/src/opentelemetry/instrumentation/openai/helpers.py
@@ -164,12 +164,12 @@ def _get_attributes_from_wrapper(instance, kwargs) -> Attributes:
         if isinstance(response_format, Mapping):
             if _is_set(response_format_type := response_format.get("type")):
                 span_attributes[GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT] = response_format_type
-        elif not isinstance(response_format, str):
+        elif isinstance(response_format, str):
+            span_attributes[GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT] = response_format
+        else:
             # Assume structured output lazily parsed to a schema via type_to_response_format_param or similar.
             # e.g. pydantic._internal._model_construction.ModelMetaclass
             span_attributes[GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT] = "json_schema"
-        else:
-            span_attributes[GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT] = response_format
 
     return span_attributes
 

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/cassettes/test_parse_response_format_json_object_with_capture_message_content.yaml
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/cassettes/test_parse_response_format_json_object_with_capture_message_content.yaml
@@ -1,0 +1,141 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Provide up to 3 words explaining why 2 + 2 equals 4 in JSON format with a 'reason' key."
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_object"
+        },
+        "stream": false
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-length:
+      - '219'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.4
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - beta.chat.completions.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.54.4
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.8
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-BCQUdjVKJTEdMSvJ2QOiAWDrK0snY",
+          "object": "chat.completion",
+          "created": 1742301475,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\n  \"reason\": \"Basic arithmetic rules\"\n}",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 33,
+            "completion_tokens": 12,
+            "total_tokens": 45,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_06737a9306"
+        }
+    headers:
+      CF-RAY:
+      - 9224c8bc4fd0d6d4-IAD
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 18 Mar 2025 12:37:55 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '853'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '349'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '200000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '199961'
+      x-ratelimit-reset-requests:
+      - 8.64s
+      x-ratelimit-reset-tokens:
+      - 11ms
+      x-request-id:
+      - req_028aaf689eb983bd5826084c8a234d93
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/cassettes/test_parse_response_format_structured_output_with_capture_message_content.yaml
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/cassettes/test_parse_response_format_structured_output_with_capture_message_content.yaml
@@ -1,0 +1,159 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Provide up to 3 words explaining why 2 + 2 equals 4 in JSON format with a 'reason' key."
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "schema": {
+              "properties": {
+                "reason": {
+                  "title": "Reason",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "reason"
+              ],
+              "title": "Reason",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "name": "Reason",
+            "strict": true
+          }
+        },
+        "stream": false
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-length:
+      - '439'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.4
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - beta.chat.completions.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.54.4
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.8
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-BCQyQRM6O8IAVbMuCXPbdLjZWwJrX",
+          "object": "chat.completion",
+          "created": 1742303322,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"reason\":\"Basic arithmetic operation\"}",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 69,
+            "completion_tokens": 8,
+            "total_tokens": 77,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_3267753c5d"
+        }
+    headers:
+      CF-RAY:
+      - 9224f5d58bc4c9b0-IAD
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 18 Mar 2025 13:08:42 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '849'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '367'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '200000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '199961'
+      x-ratelimit-reset-requests:
+      - 8.64s
+      x-ratelimit-reset-tokens:
+      - 11ms
+      x-request-id:
+      - req_1d2a78ae178add9f8c2bece1d549d000
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/test_beta_chat_completions.py
+++ b/instrumentation/elastic-opentelemetry-instrumentation-openai/tests/test_beta_chat_completions.py
@@ -1522,11 +1522,6 @@ def test_parse_response_format_json_object_with_capture_message_content(
 
     client = openai.OpenAI()
 
-    from pydantic import BaseModel
-
-    class Reason(BaseModel):
-        reason: str
-
     chat_input = """Provide up to 3 words explaining why 2 + 2 equals 4 in JSON format with a 'reason' key."""
     messages = [{"role": "user", "content": chat_input}]
 


### PR DESCRIPTION
## What does this pull request do?

Pydantic types are passed directly in as the response_format.

e.g. from DeepSeek:

```python
                if self.model_name in structured_outputs_models:
                    print(f"structured_outputs_models: {type(schema)}")

                    completion = await client.beta.chat.completions.parse(
                        model=self.model_name,
                        messages=[
                            {"role": "user", "content": prompt},
                        ],
                        response_format=schema,
                    )
```

These are lazily resolved with logic we unlikely want to recreate here, so this just maps the default case where we don't have a string to `json_schema`.

In doing so, I can see this removes the attribute warnings below as the value is now always a string:

```
WARNING  opentelemetry.attributes:__init__.py:100 Invalid type ModelMetaclass for attribute 'gen_ai.openai.request.response_format' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

## Related issues

Closes #64
